### PR TITLE
Bugfix for new telnet protocol, addresses #3

### DIFF
--- a/remote_control/control.py
+++ b/remote_control/control.py
@@ -100,7 +100,7 @@ def initialise_and_login(config):
             try:
                 expect(['Benutzername:', 'User:'])
                 sendline(config['user'])
-                expect(['Passwort:', 'Password'])
+                expect(['Passwort:', 'Password:'])
                 sendline(config['password'])
                 result = readline()
 

--- a/remote_control/control.py
+++ b/remote_control/control.py
@@ -36,7 +36,7 @@ def expect(expected, timeout=30):
     if isinstance(expected, str):
         expected = [expected] 
     if isinstance(expected, list):
-        expected = [item.encode() for item in expected if isinstance(item,str)]
+        expected = [item.encode() for item in expected if isinstance(item, str)]
     idx, match, data = telnet.expect(expected, timeout)
     data = str(data, 'utf-8')
     logfile.write(datetime.now().isoformat() + ': ' + data + '\r\n')

--- a/remote_control/control.py
+++ b/remote_control/control.py
@@ -162,6 +162,12 @@ def get_position(autofocus=False, reset_light_to=100):
         flush_output_buffer()
         sendline('GetPos')
         coord_line = readline()
+        # On the newer version of APS Maldi control I observed
+        # that the command that has been sent is echoed back.
+        # If we observe an echoed line, read another line to get
+        # the data
+        if coord_line.startswith('GetPos'):
+            coord_line = readline()
         coord_strs = coord_line.strip().replace(';OK','').split(';')
         coords = tuple(map(float, coord_strs))
 

--- a/remote_control/control.py
+++ b/remote_control/control.py
@@ -34,7 +34,9 @@ class ExpectException(Exception):
 
 def expect(expected, timeout=30):
     if isinstance(expected, str):
-        expected = [expected.encode()]
+        expected = [expected] 
+    if isinstance(expected, list):
+        expected = [item.encode() for item in expected if isinstance(item,str)]
     idx, match, data = telnet.expect(expected, timeout)
     data = str(data, 'utf-8')
     logfile.write(datetime.now().isoformat() + ': ' + data + '\r\n')
@@ -96,9 +98,9 @@ def initialise_and_login(config):
             telnet = Telnet(config['host'])
 
             try:
-                expect('Benutzername:')
+                expect(['Benutzername:', 'User:'])
                 sendline(config['user'])
-                expect('Passwort:')
+                expect(['Passwort:', 'Password'])
                 sendline(config['password'])
                 result = readline()
 


### PR DESCRIPTION
See discussion in #3 

After reading the `telnetlib` documentation I saw that `Telnet.expect` can take list arguments, i.e. we can expect either the German or the English login prompt with a single expect command. This required some changes in the `expect` wrapper function that encodes strings to binary and does some logging.
The observed echo problem is addressed by checking for an echoed command and re-reading the line if necessary.