### PR TITLE
Change package name to avoid clashes with pypi packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 from remote_control import __version__
 
-setup(name='remote_control',
+setup(name='ims_direct_control',
       version=__version__,
       description='Python library for controlling the TransMIT APS-MALDI source remotely',
       url='',


### PR DESCRIPTION
Renamed the installed package to `ims-direct-control` to be consistent with package repo name and avoid clashes with existing `remote_control` package on pypi.
Module names (for imports) remain unchanged.